### PR TITLE
azure pipeline CI to release native versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,18 @@
 ](https://hub.docker.com/r/mrothy/scalafmt-native)
 
 Statically-linked GraalVM "native image" binaries of [`scalafmt`] packaged for
-Docker. These are totally self-contained, start instantly, and do not require
-the JVM to run.
+Linux, macOS, and Docker. These are totally self-contained, start instantly, and
+do not require the JVM to run.
 
 Full size is about 32MB uncompressed.
 
 [`scalafmt`]: https://scalameta.org/scalafmt/
 
-### Usage
+### macOS and Linux
+
+Download the latest version from the [releases page](https://github.com/mroth/scalafmt-native/releases/latest).
+
+### Docker
 Sample usage running on a local `src` directory:
 
     docker pull mrothy/scalafmt-native

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,7 +13,7 @@ trigger:
     - refs/tags/*
 
 jobs:
-# Initial task to compile a JAR, store as an artifact to be used by
+# Initial task to compile a JAR, store as a pipeline artifact to be used by
 # downstream builders.
 - job: BuildJAR
   pool:
@@ -24,35 +24,41 @@ jobs:
       sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2EE0EA64E40A89B84B2DF73499E82A75642AC823
       sudo apt-get update
       sudo apt-get install sbt
-    displayName: install sbt
+    displayName: Install SBT
   - script: |
       git clone https://github.com/scalameta/scalafmt --branch ${SCALAFMT_VERSION} --single-branch
       cd scalafmt
       sbt cli/assembly
-    displayName: build scalafmt
+    displayName: Build scalafmt with assembly into JAR
   - task: PublishPipelineArtifact@0
     inputs:
       targetPath: scalafmt/scalafmt-cli/target/scala-2.12/scalafmt.jar
       artifactName: jar
 
-# Parallel native builders using template
+# Parallel native builders using template, each builds on corresponding OS and
+# packages into archive, then sends results into artifact pipeline.
 - template: ci/native-build.yml 
   parameters:
     name: BuildNative_Linux
-    platform: 'linux-amd64'
-    vmImage: 'ubuntu-16.04'
+    platform: linux-amd64
+    vmImage: ubuntu-16.04
     binPath: bin
     buildFlags: '--static'
 
 - template: ci/native-build.yml
   parameters:
     name: BuildNative_macOS
-    platform: 'macos-amd64'
-    vmImage: 'macOS-10.14'
+    platform: macOS-amd64
+    vmImage: macOS-10.14
     binPath: Contents/Home/bin
 
-# Packager (and uploader), can be any pool
-- job: PackageAndUploadReleases
+# Releaser, gets everything from artifact pipeline, and then uploads to GitHub
+# Releases if there is a semver tag.
+#
+# Currently this requires the GitHub "release" to not already exist due to
+# 'create' action usage, TODO: if this can be made to work with 'edit' as well.
+# Prior the 'edit' action was not working with 'auto' tag(?).
+- job: UploadReleases
   dependsOn:
     - BuildNative_macOS
     - BuildNative_Linux
@@ -60,33 +66,21 @@ jobs:
   - task: DownloadPipelineArtifact@0
     inputs:
       artifactName: dist_linux-amd64
-      targetPath: $(System.DefaultWorkingDirectory)/dist/linux
+      targetPath: $(Build.ArtifactStagingDirectory)
   - task: DownloadPipelineArtifact@0
     inputs:
       artifactName: dist_macOS-amd64
-      targetPath: $(System.DefaultWorkingDirectory)/dist/macOS
-  - task: ArchiveFiles@2
-    inputs:
-      rootFolderOrFile: $(System.DefaultWorkingDirectory)/dist/linux/scalafmt-native
-      archiveType: 'zip'
-      archiveFile: $(System.DefaultWorkingDirectory)/dist/release/scalafmt-native_linux-amd64.zip
-  - task: ArchiveFiles@2
-    inputs:
-      rootFolderOrFile: $(System.DefaultWorkingDirectory)/dist/macOS/scalafmt-native
-      archiveType: 'zip'
-      archiveFile: $(System.DefaultWorkingDirectory)/dist/release/scalafmt-native_macOS-amd64.zip 
-  - task: PublishPipelineArtifact@0
-    inputs:
-      artifactName: releaseDist
-      targetPath: $(System.DefaultWorkingDirectory)/dist/release
+      targetPath: $(Build.ArtifactStagingDirectory)
+  - script: ls -lh $(Build.ArtifactStagingDirectory)
   - task: GithubRelease@0
     condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/v'))
     inputs:
       gitHubConnection: 'GitHub-mroth-oauth'
       repositoryName: 'mroth/scalafmt-native'
-      action: 'create'
+      action: create
       target: '$(Build.SourceVersion)'
-      tagSource: 'auto'
-      assets: '$(System.DefaultWorkingDirectory)/dist/release/*.zip'
-      assetUploadMode: 'replace'  
+      tagSource: auto
+      # By default, all files in the $(Build.ArtifactStagingDirectory) directory will be uploaded.
+      # assets: '$(Build.ArtifactStagingDirectory)/*.tgz' 
+      assetUploadMode: replace  
       addChangeLog: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,92 @@
+# Somse useful references found thus far:
+# https://docs.microsoft.com/en-us/azure/devops/pipelines/process/multiple-phases?view=azure-devops&tabs=yaml
+# https://github.com/peterheesterman/chit/blob/master/azure-pipelines.yml
+
+variables:
+  scalafmt_version: v2.0.0-RC7
+  graalvm_version: 1.0.0-rc16
+
+trigger:
+  branches:
+    include:
+    - refs/heads/*
+    - refs/tags/*
+
+jobs:
+# Initial task to compile a JAR, store as an artifact to be used by
+# downstream builders.
+- job: BuildJAR
+  pool:
+    vmImage: 'ubuntu-16.04'
+  steps:
+  - script: |
+      echo "deb https://dl.bintray.com/sbt/debian /" | sudo tee -a /etc/apt/sources.list.d/sbt.list
+      sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2EE0EA64E40A89B84B2DF73499E82A75642AC823
+      sudo apt-get update
+      sudo apt-get install sbt
+    displayName: install sbt
+  - script: |
+      git clone https://github.com/scalameta/scalafmt --branch ${SCALAFMT_VERSION} --single-branch
+      cd scalafmt
+      sbt cli/assembly
+    displayName: build scalafmt
+  - task: PublishPipelineArtifact@0
+    inputs:
+      targetPath: scalafmt/scalafmt-cli/target/scala-2.12/scalafmt.jar
+      artifactName: jar
+
+# Parallel native builders using template
+- template: ci/native-build.yml 
+  parameters:
+    name: BuildNative_Linux
+    platform: 'linux-amd64'
+    vmImage: 'ubuntu-16.04'
+    binPath: bin
+    buildFlags: '--static'
+
+- template: ci/native-build.yml
+  parameters:
+    name: BuildNative_macOS
+    platform: 'macos-amd64'
+    vmImage: 'macOS-10.14'
+    binPath: Contents/Home/bin
+
+# Packager (and uploader), can be any pool
+- job: PackageAndUploadReleases
+  dependsOn:
+    - BuildNative_macOS
+    - BuildNative_Linux
+  steps:
+  - task: DownloadPipelineArtifact@0
+    inputs:
+      artifactName: dist_linux-amd64
+      targetPath: $(System.DefaultWorkingDirectory)/dist/linux
+  - task: DownloadPipelineArtifact@0
+    inputs:
+      artifactName: dist_macOS-amd64
+      targetPath: $(System.DefaultWorkingDirectory)/dist/macOS
+  - task: ArchiveFiles@2
+    inputs:
+      rootFolderOrFile: $(System.DefaultWorkingDirectory)/dist/linux/scalafmt-native
+      archiveType: 'zip'
+      archiveFile: $(System.DefaultWorkingDirectory)/dist/release/scalafmt-native_linux-amd64.zip
+  - task: ArchiveFiles@2
+    inputs:
+      rootFolderOrFile: $(System.DefaultWorkingDirectory)/dist/macOS/scalafmt-native
+      archiveType: 'zip'
+      archiveFile: $(System.DefaultWorkingDirectory)/dist/release/scalafmt-native_macOS-amd64.zip 
+  - task: PublishPipelineArtifact@0
+    inputs:
+      artifactName: releaseDist
+      targetPath: $(System.DefaultWorkingDirectory)/dist/release
+  - task: GithubRelease@0
+    condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/v'))
+    inputs:
+      gitHubConnection: 'GitHub-mroth-oauth'
+      repositoryName: 'mroth/scalafmt-native'
+      action: 'create'
+      target: '$(Build.SourceVersion)'
+      tagSource: 'auto'
+      assets: '$(System.DefaultWorkingDirectory)/dist/release/*.zip'
+      assetUploadMode: 'replace'  
+      addChangeLog: true

--- a/ci/native-build.yml
+++ b/ci/native-build.yml
@@ -14,6 +14,7 @@ jobs:
   variables:
     platform: ${{ parameters.platform }}
     bin_path: ${{ parameters.binPath }}
+    build_flags: ${{ parameters.buildFlags }}
   steps:
   - task: DownloadPipelineArtifact@0
     inputs:
@@ -32,7 +33,6 @@ jobs:
         -jar ./scalafmt.jar \
         scalafmt-native
       ls -lh
-      env
     displayName: Build ${{ parameters.platform }} native image
   - task: ArchiveFiles@2
     inputs:

--- a/ci/native-build.yml
+++ b/ci/native-build.yml
@@ -1,0 +1,39 @@
+parameters:
+  name: ''
+  platform: 'linux-amd64'  # currently macos-amd64 or linux-amd64
+  vmImage: 'ubuntu-16.04'
+  binPath: 'bin'
+  buildFlags: '' #extra build flags requested
+
+jobs:
+- job: ${{ parameters.name }}
+  dependsOn:
+    - BuildJAR
+  pool: 
+    vmImage: ${{ parameters.vmImage }}
+  variables:
+    platform: ${{ parameters.platform }}
+    bin_path: ${{ parameters.binPath }}
+  steps:
+  - task: DownloadPipelineArtifact@0
+    inputs:
+      artifactName: jar
+      targetPath: $(System.DefaultWorkingDirectory)
+  - script: |
+      curl -fsL https://github.com/oracle/graal/releases/download/vm-$(graalvm_version)/graalvm-ce-${GRAALVM_VERSION}-${PLATFORM}.tar.gz \
+        --output graalvm.tgz
+      tar xzf graalvm.tgz && rm -rf graalvm.tgz
+      mv graalvm-ce-$(graalvm_version) graalvm
+    displayName: Install GraalVM
+  - script: |
+      JAVA_OPTS="-Xmx=2g" ./graalvm/${BIN_PATH}/native-image \
+        ${BUILD_FLAGS} \
+        --no-fallback \
+        -jar ./scalafmt.jar \
+        scalafmt-native
+      ls -lh
+    displayName: Build ${{ parameters.platform }} native image
+  - task: PublishPipelineArtifact@0
+    inputs:
+      artifactName: dist_${{ parameters.platform }}
+      targetPath: $(System.DefaultWorkingDirectory)/scalafmt-native

--- a/ci/native-build.yml
+++ b/ci/native-build.yml
@@ -1,9 +1,9 @@
 parameters:
   name: ''
-  platform: 'linux-amd64'  # currently macos-amd64 or linux-amd64
-  vmImage: 'ubuntu-16.04'
-  binPath: 'bin'
-  buildFlags: '' #extra build flags requested
+  platform: linux-amd64  # currently macOS-amd64 or linux-amd64
+  vmImage: ubuntu-16.04
+  binPath: bin
+  buildFlags: '' # any extra build flags requested
 
 jobs:
 - job: ${{ parameters.name }}
@@ -32,10 +32,15 @@ jobs:
         -jar ./scalafmt.jar \
         scalafmt-native
       ls -lh
+      env
     displayName: Build ${{ parameters.platform }} native image
-  - script: chmod a+x scalafmt-native
-    displayName: set executable bit on native image
+  - task: ArchiveFiles@2
+    inputs:
+      rootFolderOrFile: $(System.DefaultWorkingDirectory)/scalafmt-native
+      archiveType: 'tar'
+      tarCompression: 'gz'
+      archiveFile: '$(Build.ArtifactStagingDirectory)/scalafmt-native_${{ parameters.platform }}.tgz'
   - task: PublishPipelineArtifact@0
     inputs:
       artifactName: dist_${{ parameters.platform }}
-      targetPath: $(System.DefaultWorkingDirectory)/scalafmt-native
+      targetPath: $(Build.ArtifactStagingDirectory)

--- a/ci/native-build.yml
+++ b/ci/native-build.yml
@@ -33,6 +33,8 @@ jobs:
         scalafmt-native
       ls -lh
     displayName: Build ${{ parameters.platform }} native image
+  - script: chmod a+x scalafmt-native
+    displayName: set executable bit on native image
   - task: PublishPipelineArtifact@0
     inputs:
       artifactName: dist_${{ parameters.platform }}


### PR DESCRIPTION
Runs on any semver tags, uploads to GitHub releases.  Current version will fail if GH release is already created, so need to just push a tagand let Azure Pipelines generate the release.