### PR TITLE
Update builder to use GraalVM 19 release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,9 @@ RUN curl https://bintray.com/sbt/rpm/rpm \
 # other tools needed
 RUN yum install -y git zlib-static
 
+# native-image is no longer bundled with graalvm :-/
+RUN gu install native-image
+
 # get the source for the version of scalafmt we want
 RUN git clone https://github.com/scalameta/scalafmt \
     --branch ${SCALAFMT_VERSION} --single-branch

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 #
 # Also see regarding potential future built-in native target support:
 # https://github.com/scalameta/scalafmt/issues/1172
-FROM oracle/graalvm-ce:1.0.0-rc16 as builder
+FROM oracle/graalvm-ce:19.0.0 as builder
 ARG SCALAFMT_VERSION=v2.0.0-RC7
 
 WORKDIR /root

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,9 @@ WORKDIR /root
 # install sbt
 RUN curl https://bintray.com/sbt/rpm/rpm \
     -o /etc/yum.repos.d/bintray-sbt-rpm.repo && \
-    yum install -y sbt
+    yum --disablerepo=ol7_developer install -y sbt
+    # ^^ temporary fix for upstream repository issue, TODO: remove me later
+    # yum install -y sbt
 
 # other tools needed
 RUN yum install -y git zlib-static

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,7 +48,7 @@ jobs:
 - template: ci/native-build.yml
   parameters:
     name: BuildNative_macOS
-    platform: macOS-amd64
+    platform: darwin-amd64
     vmImage: macOS-10.14
     binPath: Contents/Home/bin
 
@@ -69,7 +69,7 @@ jobs:
       targetPath: $(Build.ArtifactStagingDirectory)
   - task: DownloadPipelineArtifact@0
     inputs:
-      artifactName: dist_macOS-amd64
+      artifactName: dist_darwin-amd64
       targetPath: $(Build.ArtifactStagingDirectory)
   - script: ls -lh $(Build.ArtifactStagingDirectory)
   - task: GithubRelease@0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,7 @@
 
 variables:
   scalafmt_version: v2.0.0-RC7
-  graalvm_version: 1.0.0-rc16
+  graalvm_version: '19.0.0'
 
 trigger:
   branches:

--- a/ci/native-build.yml
+++ b/ci/native-build.yml
@@ -21,7 +21,7 @@ jobs:
       artifactName: jar
       targetPath: $(System.DefaultWorkingDirectory)
   - script: |
-      curl -fsL https://github.com/oracle/graal/releases/download/vm-$(graalvm_version)/graalvm-ce-${GRAALVM_VERSION}-${PLATFORM}.tar.gz \
+      curl -fsL https://github.com/oracle/graal/releases/download/vm-$(graalvm_version)/graalvm-ce-${PLATFORM}-${GRAALVM_VERSION}.tar.gz \
         --output graalvm.tgz
       tar xzf graalvm.tgz && rm -rf graalvm.tgz
       mv graalvm-ce-$(graalvm_version) graalvm

--- a/ci/native-build.yml
+++ b/ci/native-build.yml
@@ -28,6 +28,10 @@ jobs:
     displayName: Install GraalVM
   - script: |
       set -e
+      ./graalvm/${BIN_PATH}/gu install native-image
+    displayName: Install native-image
+  - script: |
+      set -e
       JAVA_OPTS="-Xmx=2g" ./graalvm/${BIN_PATH}/native-image \
         ${BUILD_FLAGS} \
         --no-fallback \

--- a/ci/native-build.yml
+++ b/ci/native-build.yml
@@ -27,6 +27,7 @@ jobs:
       mv graalvm-ce-$(graalvm_version) graalvm
     displayName: Install GraalVM
   - script: |
+      set -e
       JAVA_OPTS="-Xmx=2g" ./graalvm/${BIN_PATH}/native-image \
         ${BUILD_FLAGS} \
         --no-fallback \


### PR DESCRIPTION
GraalVM 19.0.0 was released, and it looks like there were quite a few API changes from the latest "release candidate" to the actual release version -- **including the removal of native-image from the default install(!)**. I guess they don't really grok the concept of a "release candidate" in the same way as the rest of us... well, lets start by just bumping the version number and seeing what breaks as a starting point.

Starting a checklist with initial expectations:
 - [x] bump version number in variables
 - [x] install native-image in docker
 - [x] archive file URL path changes for binary download
 - [x] install native-image in macos/linux